### PR TITLE
Change namespace to string

### DIFF
--- a/charts/k8sosquery/Chart.yaml
+++ b/charts/k8sosquery/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3

--- a/charts/k8sosquery/templates/NOTES.txt
+++ b/charts/k8sosquery/templates/NOTES.txt
@@ -10,17 +10,17 @@ Get the application URL by running these commands:
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Values.namespace.name }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "k8sosquery.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Values.namespace.name }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ .Values.namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "k8sosquery.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Values.namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace.name }} svc -w {{ include "k8sosquery.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace.name }} {{ include "k8sosquery.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace }} svc -w {{ include "k8sosquery.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace }} {{ include "k8sosquery.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Values.namespace.name }} -l "app.kubernetes.io/name={{ include "k8sosquery.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Values.namespace.name }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Values.namespace }} -l "app.kubernetes.io/name={{ include "k8sosquery.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Values.namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Values.namespace.name }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  kubectl --namespace {{ .Values.namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}

--- a/charts/k8sosquery/templates/configmap.yaml
+++ b/charts/k8sosquery/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.configmap.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: uptycs-config
     app.kubernetes.io/version: 1.0.0

--- a/charts/k8sosquery/templates/daemonset.yaml
+++ b/charts/k8sosquery/templates/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Values.daemonset.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: uptycs-osquery
     app.kubernetes.io/version: 1.0.0

--- a/charts/k8sosquery/templates/namespace.yaml
+++ b/charts/k8sosquery/templates/namespace.yaml
@@ -1,8 +1,8 @@
-{{- if not (lookup "v1" "Namespace" ""  .Values.namespace.name ) }}
+{{- if not (lookup "v1" "Namespace" ""  .Values.namespace ) }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.namespace.name }}
+  name: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: uptycs
     app.kubernetes.io/version: 1.0.0

--- a/charts/k8sosquery/templates/nginx-secret.yaml
+++ b/charts/k8sosquery/templates/nginx-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: nginx-secret
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
 type: Opaque
 stringData:
   ca.crt: |

--- a/charts/k8sosquery/templates/security-context-constraints.yaml
+++ b/charts/k8sosquery/templates/security-context-constraints.yaml
@@ -34,7 +34,7 @@ supplementalGroups:
 seccompProfiles:
 - '*'
 users:
-- system:serviceaccount:{{ .Values.namespace.name }}:uptycs-osquery
+- system:serviceaccount:{{ .Values.namespace }}:uptycs-osquery
 volumes:
 - '*'
 {{- end }}

--- a/charts/k8sosquery/templates/serviceaccount.yaml
+++ b/charts/k8sosquery/templates/serviceaccount.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: uptycs-osquery
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}

--- a/charts/k8sosquery/templates/uptycs-secret.yaml
+++ b/charts/k8sosquery/templates/uptycs-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: uptycs-secret
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: uptycs-secret
     app.kubernetes.io/version: 1.0.0

--- a/charts/k8sosquery/values.yaml
+++ b/charts/k8sosquery/values.yaml
@@ -7,8 +7,7 @@
 # For GKE clusters please use gke-values.yaml file.
 
 # Kubernetes resources used by K8sosquery are scoped to uptycs namespace.
-namespace:
-  name: uptycs
+namespace: uptycs
 
 # K8sosquery runs as a daemonset meaning one pod on each node of the cluster.
 # Daemonset pods run in privileged mode to access the host & container telemetry.

--- a/charts/kubequery/Chart.yaml
+++ b/charts/kubequery/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2

--- a/charts/kubequery/templates/aks-eventhub-secret.yaml
+++ b/charts/kubequery/templates/aks-eventhub-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: eventhub.secret
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
 type: Opaque
 stringData:
   eventhub.secret: {{ .Values.auditLogDetections.aks.aks_eventhub_secret }}

--- a/charts/kubequery/templates/clusterrolebinding.yaml
+++ b/charts/kubequery/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ subjects:
     {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
     namespace: {{ .Values.openshift.namespace.name }}
     {{- else }}
-    namespace: {{ .Values.namespace.name }}
+    namespace: {{ .Values.namespace }}
     {{- end }}

--- a/charts/kubequery/templates/configmap.yaml
+++ b/charts/kubequery/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
   namespace: {{ .Values.openshift.namespace.name }}
   {{- else }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   {{- end }}
 data:
   kubequery.flags: |-

--- a/charts/kubequery/templates/deployment.yaml
+++ b/charts/kubequery/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
   namespace: {{ .Values.openshift.namespace.name }}
   {{- else }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   {{- end }}
 spec:
   replicas: 1

--- a/charts/kubequery/templates/enroll-secret.yaml
+++ b/charts/kubequery/templates/enroll-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
   namespace: {{ .Values.openshift.namespace.name }}
   {{- else }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   {{- end }}
 type: Opaque
 stringData:

--- a/charts/kubequery/templates/gke-secret.yaml
+++ b/charts/kubequery/templates/gke-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gke.secret
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
 type: Opaque
 data:
   gke.secret: {{ .Values.auditLogDetections.gke.gke_secret }}

--- a/charts/kubequery/templates/namespace.yaml
+++ b/charts/kubequery/templates/namespace.yaml
@@ -1,4 +1,4 @@
-{{- if not (lookup "v1" "Namespace" ""  .Values.namespace.name ) }}
+{{- if not (lookup "v1" "Namespace" ""  .Values.namespace ) }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -10,6 +10,6 @@ metadata:
   {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
   name: {{ .Values.openshift.namespace.name }}
   {{- else }}
-  name: {{ .Values.namespace.name }}
+  name: {{ .Values.namespace }}
   {{- end }}
 {{- end }}

--- a/charts/kubequery/templates/nginx-secret.yaml
+++ b/charts/kubequery/templates/nginx-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
   namespace: {{ .Values.openshift.namespace.name }}
   {{- else }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   {{- end }}
 type: Opaque
 stringData:

--- a/charts/kubequery/templates/service-webhook-gatekeeper.yaml
+++ b/charts/kubequery/templates/service-webhook-gatekeeper.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
   namespace: {{ .Values.openshift.namespace.name }}
   {{- else }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   {{- end }}
 spec:
   ports:

--- a/charts/kubequery/templates/service-webhook.yaml
+++ b/charts/kubequery/templates/service-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
   namespace: {{ .Values.openshift.namespace.name }}
   {{- else }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   {{- end }}
 spec:
   ports:

--- a/charts/kubequery/templates/serviceaccount.yaml
+++ b/charts/kubequery/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
   namespace: {{ .Values.openshift.namespace.name }}
   {{- else }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   {{- end }}
 secrets:
   - name: webhook-server-tls

--- a/charts/kubequery/templates/validatingwebhookconfiguration-webhook-gatekeeper.yaml
+++ b/charts/kubequery/templates/validatingwebhookconfiguration-webhook-gatekeeper.yaml
@@ -13,7 +13,7 @@ webhooks:
       caBundle: {{ .Values.webhook.caBundle }}
       service:
         name: kubequery-webhook-gatekeeper
-        namespace: {{ .Values.namespace.name }}
+        namespace: {{ .Values.namespace }}
         path: /v1/admit
     failurePolicy: Ignore
     matchPolicy: Exact

--- a/charts/kubequery/templates/validatingwebhookconfiguration-webhook.yaml
+++ b/charts/kubequery/templates/validatingwebhookconfiguration-webhook.yaml
@@ -11,7 +11,7 @@ webhooks:
       caBundle: {{ .Values.webhook.caBundle }}
       service:
         name: kubequery-webhook
-        namespace: {{ .Values.namespace.name }}
+        namespace: {{ .Values.namespace }}
         path: /validate
     failurePolicy: Ignore
     sideEffects: None

--- a/charts/kubequery/templates/webhook-server-tls-secret.yaml
+++ b/charts/kubequery/templates/webhook-server-tls-secret.yaml
@@ -8,6 +8,6 @@ metadata:
   {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1" }}
   namespace: {{ .Values.openshift.namespace.name }}
   {{- else }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Values.namespace }}
   {{- end }}
 type: kubernetes.io/tls

--- a/charts/kubequery/values.yaml
+++ b/charts/kubequery/values.yaml
@@ -3,8 +3,7 @@
 # Declare variables to be passed into your templates.
 
 # Kubernetes resources used by Kubequery are scoped to kubequery namespace.
-namespace:
-  name: kubequery
+namespace: kubequery
 
 # Incase of RedHat OpenShift clusters, Kubernetes resources used by Kubequery are scoped to uptycs-kubequery namespace.
 openshift:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description

The current configuration has the namespace value set as a string inside of a map even though nothing else exists inside of that map:
```
namespace:
    name: uptycs
```
A simpler approach would be to just use a string:
```
namespace: uptycs
```

I needed to make this change because of our argo-cd deployment setup -- we're already using "namespace" as a string for all of our other charts, but because namespace here is assigned as a map, it breaks upon deployment because the two are incompatible with each other.

I currently have to manually make all of the modifications in this PR any time there's a chart update here, so I thought I'd push the change up assuming that doesn't break anything with y'all.

### Detailed summary of how this change has been tested (mandatory)

- Outside of `helm install k8sosquery ./k8sosquery -f ./override.yaml --dry-run` to verify that output creates valid yaml, I'm using this version of the helm chart in a number of clusters.

- Also tested the changes by installing both K8sosquery & Kubequery onto an EKS cluster using the updated Helm charts to ensure K8s resources are created in the correct namespace:
<img width="1670" alt="Screenshot 2024-03-12 at 2 06 17 AM copy" src="https://github.com/uptycslabs/kspm-helm-charts/assets/137804745/400518e3-2cee-475e-8468-4ef9e7b74778">

- [ ] Details included in Unit Tests
- [x] Details included in Integration Tests
- [x] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
