### PR TITLE
Remove bi-directional mount propagation in osquery charts

### DIFF
--- a/charts/k8sosquery/Chart.yaml
+++ b/charts/k8sosquery/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.1.6

--- a/charts/k8sosquery/gke-values.yaml
+++ b/charts/k8sosquery/gke-values.yaml
@@ -44,7 +44,6 @@ daemonset:
     - name: host
       mountPath: /host
       readOnly: true
-      mountPropagation: Bidirectional
     # This is mounted read-write and should start with host mount path
     - name: osquery
       mountPath: /host/home/uptycs/osquery

--- a/charts/k8sosquery/values.yaml
+++ b/charts/k8sosquery/values.yaml
@@ -42,7 +42,6 @@ daemonset:
     - name: host
       mountPath: /host
       readOnly: true
-      mountPropagation: Bidirectional
     # This is mounted read-write and should start with host mount path
     - name: osquery
       mountPath: /host/opt/uptycs/osquery


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description

The bi-directional mount propagation parameter has been removed to ensure no stray resources are left behind.

<!-- Provide a detailed summary of your change. Add reference links to design. -->

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- [ ] Details included in Unit Tests
- [ ] Details included in Integration Tests
- [x] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
