### PR TITLE
CON-5400: Revert K8sosquery config_refresh interval back to 60s

### DIFF
--- a/charts/k8sosquery/Chart.yaml
+++ b/charts/k8sosquery/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.7
+version: 1.1.8

--- a/charts/k8sosquery/gke-values.yaml
+++ b/charts/k8sosquery/gke-values.yaml
@@ -126,7 +126,7 @@ configmap:
       --compliance_data_limit=10240
       --config_accelerated_refresh=900
       --config_plugin=tls
-      --config_refresh=900
+      --config_refresh=60
       --config_tls_endpoint=/agent/config
       --config_tls_max_attempts=1
       --containerd_socket=/run/containerd/containerd.sock

--- a/charts/k8sosquery/values.yaml
+++ b/charts/k8sosquery/values.yaml
@@ -117,7 +117,7 @@ configmap:
       --compliance_data_limit=10240
       --config_accelerated_refresh=900
       --config_plugin=tls
-      --config_refresh=900
+      --config_refresh=60
       --config_tls_endpoint=/agent/config
       --config_tls_max_attempts=1
       --containerd_socket=/run/containerd/containerd.sock


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description

<!-- Provide a detailed summary of your change. Add reference links to design. -->

- Changes to revert K8sosquery `config_refresh` interval back to `60s`

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- [ ] Details included in Unit Tests
- [ ] Details included in Integration Tests
- [ ] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
