### PR TITLE
CON-5552: Move Compliance CRDs from Uptycs cloud to Helm

### DIFF
--- a/charts/k8sosquery/Chart.yaml
+++ b/charts/k8sosquery/Chart.yaml
@@ -16,3 +16,6 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.2.0
+
+# Chart icon from Uptycs website https://www.uptycs.com/
+icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/k8sosquery/Chart.yaml
+++ b/charts/k8sosquery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/kubequery/Chart.yaml
+++ b/charts/kubequery/Chart.yaml
@@ -15,4 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
+
+# Chart icon from Uptycs website https://www.uptycs.com/
+icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/kubequery/crds/001_compliance_rule_crd.yaml
+++ b/charts/kubequery/crds/001_compliance_rule_crd.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: compliancerules.compliance.uptycs.io
+spec:
+  group: compliance.uptycs.io
+  names:
+    kind: ComplianceRule
+    listKind: ComplianceRuleList
+    plural: compliancerules
+    singular: compliancerule
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: Compliance Rules are the checks related to various compliance standards like NSA
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          complianceID:
+            description: 'compliance ID is the identifier associated with the compliance Rule'
+            type: string
+          standards:
+            description: 'standards are the compliance standards for which the rule is applicable'
+            type: string           
+          title:
+            description: 'description of compliance rule'
+            type: string              
+          remediation:
+            description: 'remediation description'
+            type: string 
+          reason:
+            description: 'additional description for the compliance rule'
+            type: string   
+          metadata:
+            type: object
+          resnotpresentcheck:
+            type: boolean
+          resources:
+            description: 'contains the resource for the compliance rule'
+            type: array 
+            items:
+              type: object
+              properties:       
+                 apiGroups:
+                   type: string
+                 apiVersions:
+                   type: string
+                 resource:
+                   type: array      
+                   items:
+                      type: string
+          spec:
+            description: RuleSpec defines the desired state of Rule.
+            type: object
+            properties:
+              rego:
+                type: string

--- a/charts/kubequery/crds/002_compliance_rule_default_config.yaml
+++ b/charts/kubequery/crds/002_compliance_rule_default_config.yaml
@@ -1,0 +1,486 @@
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N001
+standards: nsa
+title: Use containers built to run applications as non-root users.
+remediation: --- 
+reason: The following pods were detected with containers with no non-root users configured
+metadata:
+  name: compliance-rule-non-root-user
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - pods
+spec:
+  rego: |
+    package filter
+    allow[result] {
+            input.object.Object.kind == "Pod"
+            not input.object.Object.spec.securityContext.runAsUser
+            result := input.object.Object.metadata.name
+    }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N002
+standards: nsa
+title: Run containers with immutable file systems
+remediation: ---
+reason: The following pods were detected with containers with readwrite file systems
+metadata:
+  name: compliance-rule-immutable-container
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - pods
+spec:
+  rego: |
+    package filter
+    allow[result] {
+            input.object.Object.kind == "Pod"
+            not is_readonlyrfs
+            result := input.object.Object.metadata.name
+    }
+    is_readonlyrfs{
+        input.object.Object.spec.containers[_].securityContext.readOnlyRootFilesystem == true
+    }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N003
+standards: nsa
+title: Define a Pod Security Policy
+remediation: ---
+reason: There is no Pod security policy defined
+metadata:
+  name: compliance-rule-no-psp
+resnotpresentcheck: yes
+resources:
+   - apiGroups: 'policy'
+     apiVersions: '*'
+     resource:
+      - podsecuritypolicies
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                result := ""
+             }
+
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N004
+standards: nsa
+title: Prevent Privileged container
+remediation: ---
+reason: The following containers have privilege configuration
+metadata:
+  name: compliance-rule-priv-container
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - pods
+spec:
+  rego: |
+    package filter
+    allow[result] {
+            input.object.Object.kind == "Pod"
+            input.object.Object.spec.containers[_].securityContext.privileged == true
+            result := input.object.Object.spec.containers[_].name
+    }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N005
+standards: nsa
+title: Deny containers with HostPID access
+remediation: ---
+reason: The following pods were detected with HostPID access
+metadata:
+  name: compliance-rule-hostpid
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - pods
+spec:
+  rego: |
+    package filter
+    allow[result] {
+            input.object.Object.kind == "Pod"
+            input.object.Object.spec.hostPID == true
+            result := input.object.Object.metadata.name
+    }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N006
+standards: nsa
+title: Deny containers with HostIPC access
+remediation: ---
+reason: The following pods were detected with HostIPC access
+metadata:
+  name: compliance-rule-hostipc
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - pods
+spec:
+  rego: |
+    package filter
+    allow[result] {
+            input.object.Object.kind == "Pod"
+            input.object.Object.spec.hostIPC == true
+            result := input.object.Object.metadata.name
+    }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N007
+standards: nsa
+title: Deny containers with HostNetwork access
+remediation: ---
+reason: The following pods were detected with HostNetwork access
+metadata:
+  name: compliance-rule-hostnetwork
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - pods
+spec:
+  rego: |
+    package filter
+    allow[result] {
+            input.object.Object.kind == "Pod"
+            input.object.Object.spec.hostNetwork == true
+            result := input.object.Object.metadata.name
+    }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N008
+standards: nsa
+title: Deny containers with allowedHostPath configurations
+remediation: --- 
+reason: Following containers have allowedHostPath configurations
+resources:
+   - apiGroups: 'policy'
+     apiVersions: '*'
+     resource:
+      - podsecuritypolicies
+metadata:
+  name: compliance-rule-psp-allowed-host-path
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                # input.object.kind == "PodSecurityPolicy"
+                not input.object.spec.allowedHostPath
+                result := input.object.metadata.name
+             }
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N009
+standards: nsa
+title: Deny containers with privilege escalation
+remediation: ---
+reason: Following pod security policies were found with privilege escalation
+resources:
+   - apiGroups: 'policy'
+     apiVersions: '*'
+     resource:
+      - podsecuritypolicies
+metadata:
+  name: compliance-rule-psp-allow-priv-escalation
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                # input.object.kind == "PodSecurityPolicy"
+                input.object.spec.allowPrivilegeEscalation == true
+                result := input.object.metadata.name
+             }
+              
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N010
+standards: nsa
+title: Deny containers with execute as root permissions
+remediation: ---
+reason: Following pod security policies were detected with execute as root permissions
+resources:
+   - apiGroups: 'policy'
+     apiVersions: '*'
+     resource:
+      - podsecuritypolicies
+metadata:
+  name: compliance-rule-psp-execute-as-root
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                # input.object.Object.kind == "Pod"
+                not input.object.spec.runasuser == "MustRunAsNonRoot"
+                result := input.object.metadata.name
+             }
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N011
+standards: nsa
+title: Enabling hardening through SELinux
+remediation: ---
+reason: Hardening through SELinux not present in policy
+resources:
+   - apiGroups: 'policy'
+     apiVersions: '*'
+     resource:
+      - podsecuritypolicies
+metadata:
+  name: compliance-rule-psp-selinux
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                # input.object.Object.kind == "Pod"
+                not input.object.spec.selinux
+                result := input.object.metadata.name
+             }
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N018
+standards: nsa
+title: Set up network policies to isolate resources including Pods, services and namespaces
+remediation: ---
+reason: Network policy does not isolate resources -
+resources:
+   - apiGroups: 'networking.k8s.io'
+     apiVersions: 'v1'
+     resource:
+      - networkpolicies
+metadata:
+  name: compliance-rule-network-podselector
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                 contains(input.object.spec.policyTypes, "Ingress")
+                 input.object.spec.ingress[_].from[_].podSelector == {}
+                 result := input.object.metadata.name
+             }
+             contains(list, element) {
+              some i
+              list[i] == element
+             }
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N019
+standards: nsa
+title: Create an explicit deny network policy(ingress/egress blocked)
+remediation: ---
+reason: Explicit deny network policy(ingress/egress blocked) not present for policy -
+resources:
+   - apiGroups: 'networking.k8s.io'
+     apiVersions: 'v1'  
+     resource:
+      - networkpolicies
+metadata:
+  name: compliance-rule-network-ingress
+spec:
+  rego: |
+    package filter 
+    allow[result] {
+      contains(input.object.spec.policyTypes, "Ingress")
+      input.object.spec.podSelector != {}
+      result :=  input.object.metadata.name
+    }
+    allow[result] {
+      contains(input.object.spec.policyTypes, "Egress")
+      input.object.spec.podSelector != {}
+      result :=  input.object.metadata.name
+    }
+    contains(list, element) {
+      some i
+      list[i] == element
+    }
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N020
+standards: nsa
+title: Set up Network Policy
+remediation: ---
+reason: No explicit nework policy defined
+resources:
+   - apiGroups: 'networking.k8s.io'
+     apiVersions: 'v1'
+     resource:
+      - networkpolicies
+metadata:
+  name: compliance-rule-network-policy
+resnotpresentcheck: yes
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                result := ""
+             }
+
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N023
+standards: nsa
+title: Use ResourceQuota policies
+remediation: ---
+reason: No ResourceQuota policies defined
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - resourcequotas
+metadata:
+  name: compliance-rule-resource-quota
+resnotpresentcheck: yes
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                result := ""
+             }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N024
+standards: nsa
+title: Use LimitRange policies
+remediation: ---
+reason: No LimitRange policies at Pod level for the following pods
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - pods
+metadata:
+  name: compliance-rule-limit-range-pod
+spec:
+  rego: |
+    package filter
+        allow[result] {
+             input.object.Object.kind == "Pod"
+             not is_cpu_limit_set
+             not is_mem_limit_set
+             result := input.object.Object.metadata.name
+             }
+             is_cpu_limit_set()
+             {
+                input.object.Object.spec.containers[_].resources.limits.cpu
+             }
+             is_mem_limit_set()
+             {
+                input.object.Object.spec.containers[_].resources.limits.memory
+             }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N026
+standards: nsa
+title: Use LimitRange policies
+remediation: ---
+reason: No LimitRange policies defined
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - limitranges
+metadata:
+  name: compliance-rule-limitrange
+resnotpresentcheck: yes
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                result := ""
+             }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N032
+standards: nsa
+title: automountServiceAccountToken should be set to false
+remediation: ---
+reason: automountServiceAccountToken should be set to true in the following pods
+resources:
+   - apiGroups: ''
+     apiVersions: v1
+     resource:
+      - pods
+metadata:
+  name: compliance-rule-automount-service-account-token
+spec:
+  rego: |
+    package filter
+        allow[result] {
+             input.object.Object.kind == "Pod"
+             not input.object.Object.spec.automountServiceAccountToken == true
+             result := input.object.Object.metadata.name
+             }
+
+---
+apiVersion: compliance.uptycs.io/v1beta1
+kind: ComplianceRule
+complianceID: N033
+standards: nsa
+title: Create RBAC policies 
+remediation: Create RBAC policies with unique roles for users, administrators, developers, service accounts, and infrastructure team.
+reason: No RBAC policies defined
+resources:
+   - apiGroups: "rbac.authorization.k8s.io"
+     apiVersions: "v1"
+     resource:
+      - roles
+   - apiGroups: "rbac.authorization.k8s.io"
+     apiVersions: "v1"
+     resource:
+      - clusterroles
+   - apiGroups: "rbac.authorization.k8s.io"
+     apiVersions: "v1"
+     resource:
+      - rolebindings
+   - apiGroups: "rbac.authorization.k8s.io"
+     apiVersions: "v1"
+     resource:
+      - clusterrolebindings
+resnotpresentcheck: yes
+metadata:
+  name: compliance-rule-rbac
+spec:
+  rego: |
+    package filter
+        allow[result] {
+                result := ""
+             }
+
+
+---


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description

<!-- Provide a detailed summary of your change. Add reference links to design. -->

- Changes to move compliance CRDs from Uptycs cloud to Helm so that they are created during Helm installation of Kubequery
- Any updates to these CRDs will still be done through cloud service

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- Integration testing on EKS cluster:
<img width="1353" alt="Screenshot 2024-08-01 at 5 53 41 PM" src="https://github.com/user-attachments/assets/c8cb9cb5-c469-4f92-a53c-def0cae3ae10">

NOTE: Testing on other cloud providers was done by QA.

- [ ] Details included in Unit Tests
- [x] Details included in Integration Tests
- [ ] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
