### PR TITLE
CON-5895: Kubequery Helm charts should deploy without specifying cluster name option

### DIFF
--- a/charts/kubequery/Chart.yaml
+++ b/charts/kubequery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.6
+version: 1.1.7
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/kubequery/templates/NOTES.txt
+++ b/charts/kubequery/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Chart {{ .Chart.Name }} has been installed successfully with the following configuration:
 
-Cluster Name used for Installation: {{ include "kubequery.deployment.hostname" . }}
+Cluster Name used: {{ include "kubequery.deployment.hostname" . }}
 
 Uptycs Protect: {{- if .Values.uptycsProtectDisabled }} Disabled {{- else }} Enabled {{- end }}
 Image Admission Controller: {{- if .Values.admissionControllerParameters.disable_image_admission_controller }} Disabled {{- else }} Enabled {{- end }}

--- a/charts/kubequery/templates/NOTES.txt
+++ b/charts/kubequery/templates/NOTES.txt
@@ -1,5 +1,7 @@
 Chart {{ .Chart.Name }} has been installed successfully with the following configuration:
 
+Cluster Name Used for Installation: {{ include "kubequery.deployment.hostname" . }}
+
 Uptycs Protect: {{- if .Values.uptycsProtectDisabled }} Disabled {{- else }} Enabled {{- end }}
 Image Admission Controller: {{- if .Values.admissionControllerParameters.disable_image_admission_controller }} Disabled {{- else }} Enabled {{- end }}
 Image Security Policy: {{- if .Values.admissionControllerParameters.disable_image_admission_controller }} No Policy Configured {{- else if or (eq .Values.admissionControllerParameters.image_security_policy "_UPTYCS_IMAGE_SECURITY_POLICY_") (not .Values.admissionControllerParameters.image_security_policy) }} uptycs_default_image_security_policy {{- else }} {{ .Values.admissionControllerParameters.image_security_policy }} {{- end }}

--- a/charts/kubequery/templates/NOTES.txt
+++ b/charts/kubequery/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Chart {{ .Chart.Name }} has been installed successfully with the following configuration:
 
-Cluster Name Used for Installation: {{ include "kubequery.deployment.hostname" . }}
+Cluster Name used for Installation: {{ include "kubequery.deployment.hostname" . }}
 
 Uptycs Protect: {{- if .Values.uptycsProtectDisabled }} Disabled {{- else }} Enabled {{- end }}
 Image Admission Controller: {{- if .Values.admissionControllerParameters.disable_image_admission_controller }} Disabled {{- else }} Enabled {{- end }}

--- a/charts/kubequery/templates/_helpers.tpl
+++ b/charts/kubequery/templates/_helpers.tpl
@@ -105,3 +105,18 @@ Service account annotation for IRSA in AWS
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Hostname for Kubequery deployment container(Cluster name that shows up in Uptycs UI).
+If .Values.deployment.spec.hostname is not set, we use the following format:
+"{{UPTYCS_TENANT}}-{{EPOCH_TIMESTAMP}}"
+*/}}
+{{- define "kubequery.deployment.hostname" -}}
+{{- $uptycsTenant := .Values.uptycsCloud | replace "." "-" }}
+{{- $currentTimestamp := now | unixEpoch }}
+{{- $hostname := printf "%s-%v" $uptycsTenant $currentTimestamp }}
+{{- if and (.Values.deployment.spec.hostname) (ne .Values.deployment.spec.hostname "_UPTYCS_CLUSTER_NAME_") }}
+{{- $hostname = .Values.deployment.spec.hostname }}
+{{- end }}
+{{- $hostname -}}
+{{- end }}

--- a/charts/kubequery/templates/deployment.yaml
+++ b/charts/kubequery/templates/deployment.yaml
@@ -20,7 +20,8 @@ spec:
         app: kubequery
         cloudprovider: {{.Values.cloudProvider}}
     spec:
-      hostname: {{ .Values.deployment.spec.hostname }}
+      {{ $hostname := include "kubequery.deployment.hostname" . }}
+      hostname: {{ $hostname }}
       hostNetwork: {{ .Values.deployment.spec.hostNetwork }}
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description

<!-- Provide a detailed summary of your change. Add reference links to design. -->

- Changes in Kubequery Helm charts to allow deploying without specifying cluster name option, when not specified we use the following format for hostname: `{UPTYCS_CLOUD}-{UNIX_TIMESTAMP}`

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- When `deployment.spec.hostname` is NOT specified:
<img width="1154" alt="Screenshot 2024-10-13 at 11 26 50 PM" src="https://github.com/user-attachments/assets/64446467-d9d9-46f3-b6d3-0beaed05e351">
<img width="1800" alt="Screenshot 2024-10-13 at 11 27 12 PM" src="https://github.com/user-attachments/assets/a906e1dd-3bdb-4ce2-8f7e-86e3c0ccd110">

- When `deployment.spec.hostname` is specified:
<img width="1338" alt="Screenshot 2024-10-23 at 4 24 16 PM" src="https://github.com/user-attachments/assets/9d00355f-da3a-4833-945a-4f0b92918c3a">
<img width="795" alt="Screenshot 2024-10-23 at 4 24 33 PM" src="https://github.com/user-attachments/assets/74ce69b0-291c-4d51-a644-f7198d7b37e0">
<img width="2301" alt="Screenshot 2024-10-23 at 4 26 31 PM" src="https://github.com/user-attachments/assets/2f2d5e2a-a40b-48dd-b25a-ad59218716e1">

- [ ] Details included in Unit Tests
- [x] Details included in Integration Tests
- [ ] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
