### PR TITLE
CON-6252: Added is_agentless flag in Kubequery configMap

### DIFF
--- a/charts/kubequery/Chart.yaml
+++ b/charts/kubequery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/kubequery/templates/configmap.yaml
+++ b/charts/kubequery/templates/configmap.yaml
@@ -44,6 +44,7 @@ data:
     {{- end }}
   {{- end }}
 {{- end }}
+    --is_agentless={{ .Values.isAgentless }}
     --disable_unmanaged_cluster_audit={{ .Values.auditLogDetections.unmanaged_cluster.disable_audit }}
     --gatekeeper_audit_interval={{ .Values.admissionControllerParameters.gatekeeper_audit_interval }}
     --disable_events=false

--- a/charts/kubequery/values.yaml
+++ b/charts/kubequery/values.yaml
@@ -43,6 +43,9 @@ deployment:
 # Uptycs cloud service onto which the cluster is enrolled.
 uptycsCloud: _UPTYCS_CLOUD_
 
+# Agentless flag controls if agentless mode is enabled.
+isAgentless: _IS_AGENTLESS_
+
 # Uptycs protect flag controls if remediation & blocking features are enabled.
 uptycsProtectDisabled: _UPTYCS_PROTECT_DISABLED_
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description

<!-- Provide a detailed summary of your change. Add reference links to design. -->

- Changes to add `is_agentless` field in Kubequery Helm chart to keep track if Kubequery is running in agentless mode

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- ConfigMap when `isAgentless: true` in `kubequery-values.yaml`:
<img width="617" alt="Screenshot 2025-01-02 at 12 01 22 AM" src="https://github.com/user-attachments/assets/ccdebd14-97b2-41ff-ac59-b7c42fa73931" />

- ConfigMap when `isAgentless: false` in `kubequery-values.yaml`:
<img width="668" alt="Screenshot 2025-01-02 at 12 01 40 AM" src="https://github.com/user-attachments/assets/136ee2fa-e84a-497c-8d39-5355093380a8" />

- [ ] Details included in Unit Tests
- [x] Details included in Integration Tests
- [ ] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
