### PR TITLE
CON-6389: Added cloud_provider flag to Kubequery ConfigMap

### DIFF
--- a/charts/kubequery/Chart.yaml
+++ b/charts/kubequery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 1.2.3
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/kubequery/templates/configmap.yaml
+++ b/charts/kubequery/templates/configmap.yaml
@@ -44,6 +44,9 @@ data:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- if .Values.cloudProvider }}
+    --cloud_provider={{ .Values.cloudProvider }}
+{{- end }}
     --is_agentless={{ .Values.isAgentless }}
     --disable_unmanaged_cluster_audit={{ .Values.auditLogDetections.unmanaged_cluster.disable_audit }}
     --gatekeeper_audit_interval={{ .Values.admissionControllerParameters.gatekeeper_audit_interval }}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description

<!-- Provide a detailed summary of your change. Add reference links to design. -->

- Changes to add `cloud_provider` flag to Kubequery ConfigMap

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- Tested changes by running `helm install --dry-run --debug kubequery -f kubequery-values.yaml ~/gitlocal/kspm-helm-charts/charts/kubequery` & verifying the `--cloud_provider` flag in generated `ConfigMap`:
<img width="669" alt="Screenshot 2025-01-30 at 9 55 09 PM" src="https://github.com/user-attachments/assets/06a81ca7-8847-4b67-bfd6-1863903ab5a2" />

- [ ] Details included in Unit Tests
- [x] Details included in Integration Tests
- [ ] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
