### PR TITLE
CON-6508: Disable kubernetes_crds table by default for OpenShift clusters

### DIFF
--- a/charts/kubequery/Chart.yaml
+++ b/charts/kubequery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.4
+version: 1.2.5
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/kubequery/templates/configmap.yaml
+++ b/charts/kubequery/templates/configmap.yaml
@@ -71,4 +71,7 @@ data:
     --distributed_interval=0
     --distributed_tls_max_attempts=3
     --config_refresh=900
+{{- if eq .Values.cloudProvider "Openshift" }}
+    --disable_tables=kubernetes_crds
+{{- end }}
   kubequery.conf: |-


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description

<!-- Provide a detailed summary of your change. Add reference links to design. -->

- Changes to disable `kubernetes_crds` table by default for `OpenShift` clusters in Kubequery Helm charts

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- [ ] Details included in Unit Tests
- [ ] Details included in Integration Tests
- [ ] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
