### PR TITLE
CON-6849: kubequery helm charts  changes for running kubequery on lin…

### DIFF
--- a/charts/kubequery/Chart.yaml
+++ b/charts/kubequery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.8
+version: 1.2.9
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/kubequery/templates/deployment.yaml
+++ b/charts/kubequery/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       {{ $hostname := include "kubequery.deployment.hostname" . }}
       hostname: {{ $hostname }}
       hostNetwork: {{ .Values.deployment.spec.hostNetwork }}
+      nodeSelector: {{ .Values.deployment.spec.nodeSelector }} 
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/kubequery/templates/deployment.yaml
+++ b/charts/kubequery/templates/deployment.yaml
@@ -19,10 +19,8 @@ spec:
       {{ $hostname := include "kubequery.deployment.hostname" . }}
       hostname: {{ $hostname }}
       hostNetwork: {{ .Values.deployment.spec.hostNetwork }}
-      {{- if .Values.deployment.spec.nodeSelector }}
       nodeSelector:
-      {{ toYaml .Values.deployment.spec.nodeSelector | indent 4 }}
-      {{- end }}
+        kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/kubequery/templates/deployment.yaml
+++ b/charts/kubequery/templates/deployment.yaml
@@ -19,7 +19,10 @@ spec:
       {{ $hostname := include "kubequery.deployment.hostname" . }}
       hostname: {{ $hostname }}
       hostNetwork: {{ .Values.deployment.spec.hostNetwork }}
-      nodeSelector: {{ .Values.deployment.spec.nodeSelector }} 
+      {{- if .Values.deployment.spec.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.deployment.spec.nodeSelector | indent 4 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/kubequery/values.yaml
+++ b/charts/kubequery/values.yaml
@@ -29,8 +29,7 @@ deployment:
     hostname: _UPTYCS_CLUSTER_NAME_
     hostNetwork: false
     nodeSelector:
-        beta.kubernetes.io/os: linux 
-       
+      beta.kubernetes.io/os: linux 
     # OPTIONAL: ImagePullSecrets to add to the kubequery-sa(Kubequery ServiceAccount) can be specified here.
     imagePullSecrets:
     # Tolerations for Kubequery pod can be defined here in this section.

--- a/charts/kubequery/values.yaml
+++ b/charts/kubequery/values.yaml
@@ -28,8 +28,6 @@ deployment:
     # This field defines the cluster name that shows up in Uptycs UI.
     hostname: _UPTYCS_CLUSTER_NAME_
     hostNetwork: false
-    nodeSelector:
-      kubernetes.io/os: linux
     # OPTIONAL: ImagePullSecrets to add to the kubequery-sa(Kubequery ServiceAccount) can be specified here.
     imagePullSecrets:
     # Tolerations for Kubequery pod can be defined here in this section.

--- a/charts/kubequery/values.yaml
+++ b/charts/kubequery/values.yaml
@@ -29,8 +29,8 @@ deployment:
     hostname: _UPTYCS_CLUSTER_NAME_
     hostNetwork: false
     nodeSelector:
-      beta.kubernetes.io/os: linux 
-    # OPTIONAL: ImagePullSecrets to add to the kubequery-sa(Kubequery ServiceAccount) can be specified here.
+      kubernetes.io/os: linux
+    #OPTIONAL: ImagePullSecrets to add to the kubequery-sa(Kubequery ServiceAccount) can be specified here.
     imagePullSecrets:
     # Tolerations for Kubequery pod can be defined here in this section.
     # Taints and tolerations work together to ensure that pods are not scheduled onto inappropriate nodes.

--- a/charts/kubequery/values.yaml
+++ b/charts/kubequery/values.yaml
@@ -30,7 +30,7 @@ deployment:
     hostNetwork: false
     nodeSelector:
       kubernetes.io/os: linux
-    #OPTIONAL: ImagePullSecrets to add to the kubequery-sa(Kubequery ServiceAccount) can be specified here.
+    # OPTIONAL: ImagePullSecrets to add to the kubequery-sa(Kubequery ServiceAccount) can be specified here.
     imagePullSecrets:
     # Tolerations for Kubequery pod can be defined here in this section.
     # Taints and tolerations work together to ensure that pods are not scheduled onto inappropriate nodes.

--- a/charts/kubequery/values.yaml
+++ b/charts/kubequery/values.yaml
@@ -28,6 +28,9 @@ deployment:
     # This field defines the cluster name that shows up in Uptycs UI.
     hostname: _UPTYCS_CLUSTER_NAME_
     hostNetwork: false
+    nodeSelector:
+        beta.kubernetes.io/os: linux 
+       
     # OPTIONAL: ImagePullSecrets to add to the kubequery-sa(Kubequery ServiceAccount) can be specified here.
     imagePullSecrets:
     # Tolerations for Kubequery pod can be defined here in this section.


### PR DESCRIPTION
…ux nodes

<!-- markdownlint-disable first-line-heading -->

### Description

<!-- Provide a detailed summary of your change. Add reference links to design. -->

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- [ ] Details included in Unit Tests
- [ ] Details included in Integration Tests
- [ ] Manually Tested (details captured elsewhere)

verify on lab cluster with new changes 

rreddy@rreddy-mac kspm-helm-charts %  helm install kubequery --set deployment.spec.hostname=test-win-cluster -f kubequery-values.yaml charts/kubequery
I1017 11:09:06.696718   58435 warnings.go:110] "Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use \"kubernetes.io/os\" instead"
NAME: kubequery
LAST DEPLOYED: Fri Oct 17 11:08:44 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Chart kubequery has been installed successfully with the following configuration:

Cluster Name used: test-win-cluster

Uptycs Protect: Enabled
Image Admission Controller: Disabled
Image Security Policy: No Policy Configured
Gatekeeper Admission Controller: Disabled
Default Gatekeeper Pod Security Policies: Not Installed
Detections on Audit Logs for AKS platform: Disabled
rreddy@rreddy-mac kspm-helm-charts % 
rreddy@rreddy-mac kspm-helm-charts % 
rreddy@rreddy-mac kspm-helm-charts % kubectl get pods -A 
NAMESPACE           NAME                                                   READY   STATUS    RESTARTS   AGE
gatekeeper-system   gatekeeper-audit-666dc6d987-79frg                      1/1     Running   0          51m
gatekeeper-system   gatekeeper-controller-68896bd7c6-24bc8                 1/1     Running   0          51m
gatekeeper-system   gatekeeper-controller-68896bd7c6-f6m6w                 1/1     Running   0          51m
kube-system         azure-cns-jfmbg                                        1/1     Running   0          50m
kube-system         azure-cns-tfctr                                        1/1     Running   0          50m
kube-system         azure-cns-vmthc                                        1/1     Running   0          50m
kube-system         azure-cns-win-b56k7                                    1/1     Running   0          48m
kube-system         azure-cns-zsbhg                                        1/1     Running   0          50m
kube-system         azure-ip-masq-agent-992gj                              1/1     Running   0          50m
kube-system         azure-ip-masq-agent-bq7ph                              1/1     Running   0          50m
kube-system         azure-ip-masq-agent-pmvkn                              1/1     Running   0          50m
kube-system         azure-ip-masq-agent-sl7rp                              1/1     Running   0          50m
kube-system         azure-policy-7d8856799f-c57xh                          1/1     Running   0          51m
kube-system         azure-policy-webhook-dc668c7dd-srsfg                   1/1     Running   0          51m
kube-system         azure-wi-webhook-controller-manager-646dc59586-btqs7   1/1     Running   0          47m
kube-system         azure-wi-webhook-controller-manager-646dc59586-l2z7j   1/1     Running   0          47m
kube-system         cloud-node-manager-gmrqg                               1/1     Running   0          50m
kube-system         cloud-node-manager-qtkgd                               1/1     Running   0          50m
kube-system         cloud-node-manager-vxcvd                               1/1     Running   0          50m
kube-system         cloud-node-manager-w48bt                               1/1     Running   0          50m
kube-system         cloud-node-manager-windows-mq9fj                       1/1     Running   0          48m
kube-system         coredns-6f776c8fb5-6bj9s                               1/1     Running   0          51m
kube-system         coredns-6f776c8fb5-t65bz                               1/1     Running   0          50m
kube-system         coredns-autoscaler-777944c647-6kt6v                    1/1     Running   0          51m
kube-system         csi-azuredisk-node-8r5zs                               3/3     Running   0          50m
kube-system         csi-azuredisk-node-cndbx                               3/3     Running   0          50m
kube-system         csi-azuredisk-node-qq5v7                               3/3     Running   0          50m
kube-system         csi-azuredisk-node-win-c2h5w                           2/2     Running   0          48m
kube-system         csi-azuredisk-node-xztkp                               3/3     Running   0          50m
kube-system         csi-azurefile-node-2j8cs                               3/3     Running   0          50m
kube-system         csi-azurefile-node-gj67s                               3/3     Running   0          50m
kube-system         csi-azurefile-node-k45kv                               3/3     Running   0          50m
kube-system         csi-azurefile-node-win-d6ffw                           2/2     Running   0          48m
kube-system         csi-azurefile-node-zfxzr                               3/3     Running   0          50m
kube-system         eraser-controller-manager-5fcc94f5d7-rxz5l             1/1     Running   0          47m
kube-system         konnectivity-agent-69454d8cb7-4b6vc                    1/1     Running   0          8m8s
kube-system         konnectivity-agent-69454d8cb7-zjjx9                    1/1     Running   0          8m6s
kube-system         konnectivity-agent-autoscaler-6ddd978bfc-gngp2         1/1     Running   0          51m
kube-system         kube-proxy-ctr4r                                       1/1     Running   0          50m
kube-system         kube-proxy-p9m8l                                       1/1     Running   0          50m
kube-system         kube-proxy-plt2g                                       1/1     Running   0          50m
kube-system         kube-proxy-znw8c                                       1/1     Running   0          50m
kube-system         metrics-server-8d66fdc99-rk25z                         2/2     Running   0          46m
kube-system         metrics-server-8d66fdc99-wzjg6                         2/2     Running   0          46m
kube-system         windows-kube-proxy-initializer-vfnjj                   1/1     Running   0          48m
kubequery           kubequery-786c9bd678-p7b98                             1/1     Running   0          27s
rreddy@rreddy-mac kspm-helm-charts % kubectl logs -f kubequery-786c9bd678-p7b98 -n kubequery 
cp: omitting directory '/opt/uptycs/config/enroll'
2025/10/17 05:39:09 kubequery logs 2025-10-17 05:39:09.45068399 +0000 UTC m=+0.029945349
I1017 05:39:09.450862       1 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I1017 05:39:09.450875       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I1017 05:39:09.450878       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I1017 05:39:09.450882       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I1017 05:39:09.450885       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
time="2025-10-17T05:39:09Z" level=info msg="readFlagsFile DisableImageAdmissionController = true DisableGatekeeperController = true DisableGatekeeperControllerPSP = true DisableSecurityEventStdout = true DisableEvents = false IsAgentless = false LoggerTLSMax = 5242880 VerboseLogging = false MaxListIterations = 1000 PaginationRowLimit = 100 LowPaginationRowLimit = 50 DisableTables = []"
2025-10-17T05:39:09Z INFO: Kubequery has sufficient resources allocated CPU Limit: 1, CPU Request: 1, Memory Limit: 1048576000 bytes, Memory Request: 524288000 bytes
2025/10/17 05:39:09 Starting Kubequery in standalone mode...
2025/10/17 05:39:09 Kubequery version: 5.1.8
2025/10/17 05:39:09 GOMEMLIMIT: 800MiB GOGC: 50
2025/10/17 05:39:09 cloud id for gcp or azure is 8da31d20-daf9-42ad-bf7f-2cdcf629d769
time="2025-10-17T05:39:09Z" level=info msg="Initializing inventory tables..."
time="2025-10-17T05:39:09Z" level=info msg="Registering driver with scheduler..." tableName=kubernetes_mutating_webhooks
time="2025-10-17T05:39:09Z" level=info msg="registered with scheduler" name=kubernetes_mutating_webhooks
time="2025-10-17T05:39:09Z" level=info msg="Registering driver with scheduler..." tableName=kubernetes_validating_webhooks
time="2025-10-17T05:39:09Z" level=info msg="registered with scheduler" name=kubernetes_validating_webhooks
time="2025-10-17T05:39:09Z" level=info msg="Registering driver with scheduler..." tableName=kubernetes_daemon_sets
time="2025-10-17T05:39:09Z" level=info msg="registered with scheduler" name=kubernetes_daemon_sets
time="2025-10-17T05:39:09Z" level=info msg="Registering driver with scheduler..." tableName=kubernetes_daemon_set_containers
time="2025-10-17T05:39:09Z" level=info msg="registered with scheduler" name=kubernetes_daemon_set_containers

- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
