### PR TITLE
Removed secret check to support gitOps and other environments

### DIFF
--- a/charts/k8sosquery/Chart.yaml
+++ b/charts/k8sosquery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.5
+version: 1.3.6
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/k8sosquery/gke-values.yaml
+++ b/charts/k8sosquery/gke-values.yaml
@@ -105,10 +105,11 @@ configmap:
 # Enroll secret contains customer identifiers & should match with allowed Uptycs infra config.
 # Nginx secret contains all the root CA's accepted by Uptycs cloud.
 secrets:
+  createNginxSecret: true
   enroll_secret: __UPTYCS_SECRET__
   nginx_secret: |-
     __NGINX_SECRET__
-  createNginxSecret: true
+  
 
 # Override the release's name.
 nameOverride: ""

--- a/charts/k8sosquery/gke-values.yaml
+++ b/charts/k8sosquery/gke-values.yaml
@@ -108,6 +108,7 @@ secrets:
   enroll_secret: __UPTYCS_SECRET__
   nginx_secret: |-
     __NGINX_SECRET__
+  createNginxSecret: true
 
 # Override the release's name.
 nameOverride: ""

--- a/charts/k8sosquery/templates/nginx-secret.yaml
+++ b/charts/k8sosquery/templates/nginx-secret.yaml
@@ -1,8 +1,8 @@
 # Create nginx secret
+{{- if .Values.secrets.createNginxSecret }}
 {{- $namespaceYaml := include "k8sosquery.namespace" . }}
 {{- $nsObj := $namespaceYaml | fromYaml }}
 {{- $namespace := $nsObj.namespace }}
-{{- if not (lookup "v1" "Secret" $namespace "nginx-secret") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,6 +12,4 @@ type: Opaque
 stringData:
   ca.crt: |
 {{ .Values.secrets.nginx_secret | indent 4 }}
-{{- else }}
-# Secret already exists, skipping creation
 {{- end }}

--- a/charts/k8sosquery/values.yaml
+++ b/charts/k8sosquery/values.yaml
@@ -98,6 +98,7 @@ secrets:
   enroll_secret: __UPTYCS_SECRET__
   nginx_secret: |-
     __NGINX_SECRET__
+  createNginxSecret: true
 
 # Override the release's name.
 nameOverride: ""

--- a/charts/k8sosquery/values.yaml
+++ b/charts/k8sosquery/values.yaml
@@ -95,10 +95,10 @@ configmap:
 # Enroll secret contains customer identifiers & should match with allowed Uptycs infra config.
 # Nginx secret contains all the root CA's accepted by Uptycs cloud.
 secrets:
+  createNginxSecret: true
   enroll_secret: __UPTYCS_SECRET__
   nginx_secret: |-
     __NGINX_SECRET__
-  createNginxSecret: true
 
 # Override the release's name.
 nameOverride: ""

--- a/charts/kubequery/Chart.yaml
+++ b/charts/kubequery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/kubequery/templates/nginx-secret.yaml
+++ b/charts/kubequery/templates/nginx-secret.yaml
@@ -1,7 +1,7 @@
+{{- if .Values.secrets.createNginxSecret }}
 {{- $namespaceYaml := include "kubequery.namespace" . }}
 {{- $nsObj := $namespaceYaml | fromYaml }}
 {{- $namespace := $nsObj.namespace }}
-{{- if not (lookup "v1" "Secret" $namespace "nginx-secret") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,6 +10,4 @@ metadata:
 type: Opaque
 stringData:
   ca.crt: {{ quote .Values.secrets.nginx_secret }}
-{{- else }}
-# Secret already exists, skipping creation
 {{- end }}

--- a/charts/kubequery/values.yaml
+++ b/charts/kubequery/values.yaml
@@ -104,6 +104,7 @@ webhookServerTLS:
 # Enroll secret contains customer identifiers & should match with allowed Uptycs infra config.
 # Nginx secret contains all the root CA's accepted by Uptycs cloud.
 secrets:
+  createNginxSecret: true
   enroll_secret: __UPTYCS_ENROLL_SECRET__
   nginx_secret: |-
     __UPTYCS_NGINX_CRT__


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description
Previously we introduced a lookup for secrets to avoid installation errors related to common secrets between kubequery and k8sosquery. The lookup functionality works only when the cluster context is available. In scenarios where this is not available, the check will fail. 
Hence to avoid such scenarios, a new variable has been added to explicitly specify which helm chart installs a secret. 


<!-- Provide a detailed summary of your change. Add reference links to design. -->

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- [ ] Details included in Unit Tests
- [x] Details included in Integration Tests
- [ ] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

Normal installation in independent namespaces for k8sosquery and kubequery

```
~/Project/gitlocal/kspm-helm-charts CON-7013* ❯ helm install k8sosquery -f ~/Downloads/k8sosquery-values.yaml charts/k8sosquery 
NAME: k8sosquery
LAST DEPLOYED: Wed Feb 11 15:23:40 2026
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Chart k8sosquery has been installed successfully with the following configuration:

Uptycs Protect: Disabled
~/Project/gitlocal/kspm-helm-charts CON-7013* 17s ❯ helm install kubequery --set deployment.spec.hostname=pod2pod-cluster -f ~/Downloads/kubequery-values.yaml  charts/kubequery
NAME: kubequery
LAST DEPLOYED: Wed Feb 11 15:24:03 2026
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Chart kubequery has been installed successfully with the following configuration:

Cluster Name used: pod2pod-cluster

Uptycs Protect: Disabled
Image Admission Controller: Disabled
Image Security Policy: No Policy Configured
Gatekeeper Admission Controller: Disabled
Default Gatekeeper Pod Security Policies: Not Installed
Detections on Audit Logs for EKS platform: Disabled

```
```
~/Project/gitlocal/kspm-helm-charts CON-7013* ❯ helm install kubequery --set deployment.spec.hostname=pod2pod-cluster -f ~/Downloads/kubequery-values.yaml  charts/kubequery --set secrets.createNginxSecret=true -n uptycs-ns --create-namespace
Error: INSTALLATION FAILED: rendered manifests contain a resource that already exists. Unable to continue with install: Secret "nginx-secret" in namespace "uptycs-ns" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "kubequery": current value is "k8sosquery"
~/Project/gitlocal/kspm-helm-charts CON-7013* 10s ❯ helm install kubequery --set deployment.spec.hostname=pod2pod-cluster -f ~/Downloads/kubequery-values.yaml  charts/kubequery --set secrets.createNginxSecret=false -n uptycs-ns --create-namespace
NAME: kubequery
LAST DEPLOYED: Wed Feb 11 15:47:47 2026
NAMESPACE: uptycs-ns
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Chart kubequery has been installed successfully with the following configuration:

Cluster Name used: pod2pod-cluster

Uptycs Protect: Disabled
Image Admission Controller: Disabled
Image Security Policy: No Policy Configured
Gatekeeper Admission Controller: Disabled
Default Gatekeeper Pod Security Policies: Not Installed
Detections on Audit Logs for EKS platform: Disabled


```

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
