### PR TITLE
CON-7015: Added K8s Pod Priority class support for K8sosquery & Kubequery Helm charts

### DIFF
--- a/charts/k8sosquery/Chart.yaml
+++ b/charts/k8sosquery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.6
+version: 1.3.7
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/k8sosquery/gke-values.yaml
+++ b/charts/k8sosquery/gke-values.yaml
@@ -75,6 +75,9 @@ daemonset:
     secret:
       secretName: nginx-secret
       optional: false
+  # Optional: name of a Kubernetes PriorityClass for the K8sosquery pods.
+  # When set, the PriorityClass must exist in the cluster before installing/upgrading the chart.
+  priorityClassName:
   # Tolerations for K8sosquery pods can be defined here in this section.
   # Taints and tolerations work together to ensure that pods are not scheduled onto inappropriate nodes.
   # For more info please refer to K8s docs: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

--- a/charts/k8sosquery/templates/daemonset.yaml
+++ b/charts/k8sosquery/templates/daemonset.yaml
@@ -22,6 +22,9 @@ spec:
         app.kubernetes.io/part-of: Uptycs
     spec:
       serviceAccountName: uptycs-osquery
+      {{- if .Values.daemonset.priorityClassName }}
+      priorityClassName: {{ .Values.daemonset.priorityClassName }}
+      {{- end }}
       {{- with .Values.daemonset.tolerations }}
       tolerations:
       {{- toYaml . | nindent 6 }}

--- a/charts/k8sosquery/values.yaml
+++ b/charts/k8sosquery/values.yaml
@@ -65,6 +65,9 @@ daemonset:
       optional: false
   # OPTIONAL: ImagePullSecrets to add to the uptycs-osquery(K8sosquery ServiceAccount) can be specified here.
   imagePullSecrets:
+  # Optional: name of a Kubernetes PriorityClass for the K8sosquery pods.
+  # When set, the PriorityClass must exist in the cluster before installing/upgrading the chart.
+  priorityClassName:
   # Tolerations for K8sosquery pods can be defined here in this section.
   # Taints and tolerations work together to ensure that pods are not scheduled onto inappropriate nodes.
   # For more info please refer to K8s docs: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

--- a/charts/kubequery/Chart.yaml
+++ b/charts/kubequery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.3.2
 
 # Chart icon from Uptycs website https://www.uptycs.com/
 icon: https://www.uptycs.com/hs-fs/hubfs/Logo-2.png?width=232&height=70&name=Logo-2.png

--- a/charts/kubequery/templates/deployment.yaml
+++ b/charts/kubequery/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{ $hostname := include "kubequery.deployment.hostname" . }}
       hostname: {{ $hostname }}
       hostNetwork: {{ .Values.deployment.spec.hostNetwork }}
+      {{- if .Values.deployment.spec.priorityClassName }}
+      priorityClassName: {{ .Values.deployment.spec.priorityClassName }}
+      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/charts/kubequery/values.yaml
+++ b/charts/kubequery/values.yaml
@@ -30,6 +30,9 @@ deployment:
     hostNetwork: false
     # OPTIONAL: ImagePullSecrets to add to the kubequery-sa(Kubequery ServiceAccount) can be specified here.
     imagePullSecrets:
+    # Optional: name of a Kubernetes PriorityClass for the Kubequery pod.
+    # When set, the PriorityClass must exist in the cluster before installing/upgrading the chart.
+    priorityClassName:
     # Tolerations for Kubequery pod can be defined here in this section.
     # Taints and tolerations work together to ensure that pods are not scheduled onto inappropriate nodes.
     # For more info please refer to K8s docs: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

### Description

<!-- Provide a detailed summary of your change. Add reference links to design. -->

- Added K8s Pod Priority class support for K8sosquery & Kubequery Helm charts

### Detailed summary of how this change has been tested (mandatory)

Describe the tests that you ran to verify your changes.
Provide instructions on how to run them.
Please add screenshots if needed.

- Priority class name specified in Kubequery `values.yaml`:
```
# Kubequery runs as a deployment meaning only one pod in a Kubernetes cluster.
deployment:
  spec:
    containers:
      image_name: uptycs/uptycs-kubequery:5.1.11
      pullPolicy: IfNotPresent
      # To enable Liveness Probe for Kubequery please follow the instructions from the following url:
      # https://{DOMAIN}{DOMAIN_SUFFIX}/help/docs/knowledge-base/configuration/liveness-probe-k8sosquey-kubequery
      resources:
        limits:
          cpu: 1000m
          memory: 1000Mi
        requests:
          cpu: 200m
          memory: 500Mi
    # This field defines the cluster name that shows up in Uptycs UI.
    hostname: _UPTYCS_CLUSTER_NAME_
    hostNetwork: false
    # OPTIONAL: ImagePullSecrets to add to the kubequery-sa(Kubequery ServiceAccount) can be specified here.
    imagePullSecrets:
    # Optional: name of a Kubernetes PriorityClass for the Kubequery pod.
    # When set, the PriorityClass must exist in the cluster before installing/upgrading the chart.
    priorityClassName: very-high-priority
    # Tolerations for Kubequery pod can be defined here in this section.
    # Taints and tolerations work together to ensure that pods are not scheduled onto inappropriate nodes.
    # For more info please refer to K8s docs: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
    tolerations:
    - key: deploy-uptycs-runtime-sensor
      value: "true"
      effect: NoSchedule
```

- Priority class set for deployment pod dynamically during Helm installation:
```
~/gitlocal/helm-values/supernova/eks/default_ag 6s
❯ kgpn kubequery
NAME                         READY   STATUS    RESTARTS   AGE
kubequery-6b4fdd6557-rrh7x   1/1     Running   0          3s

~/gitlocal/helm-values/supernova/eks/default_ag
❯ kgpn kubequery kubequery-6b4fdd6557-rrh7x -o yaml | grep 'priorityClassName'
  priorityClassName: very-high-priority

~/gitlocal/helm-values/supernova/eks/default_ag
❯ kg priorityclasses.scheduling.k8s.io
NAME                      VALUE        GLOBAL-DEFAULT   AGE    PREEMPTIONPOLICY
system-cluster-critical   2000000000   false            11d    PreemptLowerPriority
system-node-critical      2000001000   false            11d    PreemptLowerPriority
very-high-priority        1000000      false            110m   PreemptLowerPriority

```

- [ ] Details included in Unit Tests
- [x] Details included in Integration Tests
- [ ] Manually Tested (details captured elsewhere)
- [ ] I did NOT test

### Security & Risks

- [ ] Is your change storing hard-coded passwords, API keys or other secrets?
- [ ] Have you used any custom hashing or encryption algorithms?
- [ ] Are there any regression risks?

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Successfully tested changes on Linux x86
- [ ] Successfully tested changes on MacOS M1
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
