### PR TITLE
k8sosquery: add commonLabels and commonAnnotations support

### DIFF
--- a/charts/k8sosquery/templates/configmap.yaml
+++ b/charts/k8sosquery/templates/configmap.yaml
@@ -10,6 +10,13 @@ metadata:
     app.kubernetes.io/version: 1.0.0
     app.kubernetes.io/component: endpoint
     app.kubernetes.io/part-of: Uptycs
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
 {{- if .Values.configmap.data.tags }}
   osquery.tags: |

--- a/charts/k8sosquery/templates/daemonset.yaml
+++ b/charts/k8sosquery/templates/daemonset.yaml
@@ -9,6 +9,13 @@ metadata:
     app.kubernetes.io/version: 1.0.0
     app.kubernetes.io/component: endpoint
     app.kubernetes.io/part-of: Uptycs
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -20,6 +27,13 @@ spec:
         app.kubernetes.io/version: 1.0.0
         app.kubernetes.io/component: endpoint
         app.kubernetes.io/part-of: Uptycs
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.commonAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: uptycs-osquery
       {{- if .Values.daemonset.priorityClassName }}

--- a/charts/k8sosquery/templates/namespace.yaml
+++ b/charts/k8sosquery/templates/namespace.yaml
@@ -9,4 +9,11 @@ metadata:
     app.kubernetes.io/version: 1.0.0
     app.kubernetes.io/component: endpoint
     app.kubernetes.io/part-of: Uptycs
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/k8sosquery/templates/nginx-secret.yaml
+++ b/charts/k8sosquery/templates/nginx-secret.yaml
@@ -8,6 +8,14 @@ kind: Secret
 metadata:
   name: nginx-secret
   {{- include "k8sosquery.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 stringData:
   ca.crt: |

--- a/charts/k8sosquery/templates/security-context-constraints.yaml
+++ b/charts/k8sosquery/templates/security-context-constraints.yaml
@@ -7,11 +7,17 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-5"
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: uptycs-osquery-privileged
     app.kubernetes.io/version: 1.0.0
     app.kubernetes.io/component: endpoint
     app.kubernetes.io/part-of: Uptycs
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 allowHostDirVolumePlugin: true
 allowHostIPC: true
 allowHostNetwork: true

--- a/charts/k8sosquery/templates/serviceaccount.yaml
+++ b/charts/k8sosquery/templates/serviceaccount.yaml
@@ -4,6 +4,17 @@ kind: ServiceAccount
 metadata:
   name: uptycs-osquery
   {{- include "k8sosquery.namespace" . }}
+  labels:
+    app.kubernetes.io/name: uptycs-osquery
+    app.kubernetes.io/component: endpoint
+    app.kubernetes.io/part-of: Uptycs
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- if .Values.daemonset.imagePullSecrets }}
 imagePullSecrets:
   - name: {{ .Values.daemonset.imagePullSecrets }}

--- a/charts/k8sosquery/templates/serviceaccount.yaml
+++ b/charts/k8sosquery/templates/serviceaccount.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: uptycs-osquery
     app.kubernetes.io/component: endpoint
     app.kubernetes.io/part-of: Uptycs
+    app.kubernetes.io/version: 1.0.0 
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/k8sosquery/templates/uptycs-secret.yaml
+++ b/charts/k8sosquery/templates/uptycs-secret.yaml
@@ -9,6 +9,13 @@ metadata:
     app.kubernetes.io/version: 1.0.0
     app.kubernetes.io/component: endpoint
     app.kubernetes.io/part-of: Uptycs
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 stringData:
   uptycs.secret: {{ .Values.secrets.enroll_secret }}

--- a/charts/k8sosquery/values.yaml
+++ b/charts/k8sosquery/values.yaml
@@ -108,6 +108,11 @@ nameOverride: ""
 # Override the release's fullname.
 fullnameOverride: ""
 
+# Labels to add to all created Kubernetes resources.
+commonLabels: {}
+# Annotations to add to all created Kubernetes resources.
+commonAnnotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
## Summary

- Adds two new top-level values, `commonLabels` and `commonAnnotations`, to the k8sosquery chart
- Both values are propagated to the `metadata` of every Kubernetes resource the chart creates: Namespace, ServiceAccount, ConfigMap, DaemonSet (resource metadata + pod template metadata), uptycs-secret, nginx-secret, and SecurityContextConstraints (OpenShift)
- Both default to `{}` so existing installs are completely unaffected

## Motivation

Users deploying into environments with mandatory label/annotation policies (e.g. cost-allocation labels, team ownership annotations, Kyverno/OPA admission policies) previously had no way to inject custom metadata onto chart-managed resources without forking the templates.

## Reviewer notes

- The ServiceAccount template also gained base `app.kubernetes.io/*` labels it was previously missing (consistent with all other resources in the chart)
- The nginx-secret template previously had no labels at all; `commonLabels` is only rendered when non-empty so there is no change to default output
- For the SecurityContextConstraints template, `commonAnnotations` is merged into the existing `annotations` block that holds the Helm hook annotations — no key conflicts are expected since Helm hook keys are namespaced under `helm.sh/`

## Test plan

- [ ] `helm template` with `commonLabels` and `commonAnnotations` set renders the values on all resources
- [ ] `helm template` with no `commonLabels`/`commonAnnotations` (default `{}`) produces output identical to the previous chart version
- [ ] Install/upgrade on a real cluster (AKS/EKS/OpenShift) with and without the new values